### PR TITLE
chore: 指定@tarojs/cli版本，规避全局依赖版本不一致导致的编译错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",
+    "@tarojs/cli": "3.4.3",
     "@tarojs/mini-runner": "3.4.3",
     "@tarojs/webpack-runner": "3.4.3",
     "@types/react": "^17.0.2",


### PR DESCRIPTION
fix #1 